### PR TITLE
Add download attribute to links

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,12 +61,12 @@
                 <div id="downloads">
                     <h3>Downloads</h3>
                     <div class="half">
-                        <a class="lin32" href="https://github.com/TheJaredWilcurt/scout-app/releases" target="_blank">Linux 32-Bit</a>
-                        <a class="lin64" href="https://github.com/TheJaredWilcurt/scout-app/releases" target="_blank">Linux 64-Bit</a>
+                        <a class="lin32" href="https://github.com/TheJaredWilcurt/scout-app/releases" download>Linux 32-Bit</a>
+                        <a class="lin64" href="https://github.com/TheJaredWilcurt/scout-app/releases" download>Linux 64-Bit</a>
                     </div>
                     <div class="half">
-                        <a class="osxupdate" href="https://github.com/TheJaredWilcurt/scout-app/releases" target="_blank">OSX</a>
-                        <a class="windowsupdate" href="https://github.com/TheJaredWilcurt/scout-app/releases" target="_blank">Windows</a>
+                        <a class="osxupdate" href="https://github.com/TheJaredWilcurt/scout-app/releases" download>OSX</a>
+                        <a class="windowsupdate" href="https://github.com/TheJaredWilcurt/scout-app/releases" download>Windows</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
It doesn't work in safari but it does make it so you aren't being redirected from the website.
